### PR TITLE
add sms support

### DIFF
--- a/src/Components/Status.tsx
+++ b/src/Components/Status.tsx
@@ -1,0 +1,10 @@
+function Status({ status, text }: { status: 'success' | 'danger' | 'muted'; text: string }) {
+	return (
+		<div className="status">
+			<div className={`circle ${status}`}></div>
+			<span>{text}</span>
+		</div>
+	);
+}
+
+export default Status;

--- a/src/Pages/Settings/Area/ChangePhone.tsx
+++ b/src/Pages/Settings/Area/ChangePhone.tsx
@@ -1,4 +1,4 @@
-import { createRef, useState } from 'react';
+import { createRef, useEffect, useState } from 'react';
 import { ReactSortable } from 'react-sortablejs';
 
 import Delete from '../../../Assets/Images/Delete.svg';
@@ -43,14 +43,14 @@ function ChangePhone({
 	PhonesCombo: Array<[string /* phone */, string /* name */]>;
 	credentials: Credentials;
 }) {
-	//remove admin phone from PhonesCombo
-	const admin = PhonesCombo.pop();
-
-	const [ButtonDisabled, setButtonDisabled] = useState(false);
-	const [ButtonValue, setButtonValue] = useState('Valider');
+	const adminPhone = PhonesCombo.pop() ?? ['super admin', 'non renseigné'];
+	const [admin, setadmin] = useState(adminPhone);
 	const [PhonesName, setPhonesName] = useState(
 		PhonesCombo.map(([phone, name], index) => ({ id: index, phone, name }))
 	);
+
+	const [ButtonDisabled, setButtonDisabled] = useState(false);
+	const [ButtonValue, setButtonValue] = useState('Valider');
 
 	const addResponse = () => {
 		let id = 0;
@@ -99,6 +99,16 @@ function ChangePhone({
 	return (
 		<div className="GenericPage">
 			<h2>Changer le numéros des administrateurs</h2>
+			<p>
+				Dans cette section, vous pouvez modifier, ajouter ou supprimer les numéros de téléphone des
+				administrateurs de cette région. Ces numéros seront utilisés pour envoyer des sms en cas de problème
+				avec les campagnes en cours, notamment des problèmes avec des utilisateurs qui spammeraient le service,
+				la fin des numéros de la campagne ou d’autres erreurs. Dans tous les cas, l'administrateur général
+				recevra une copie de tous les messages. Sur cette instance, l'administrateur général est:{' '}
+				<a href={`tel:${admin[0]}`} className="Phone">
+					<u>{admin[0]}</u>
+				</a>
+			</p>
 			<ReactSortable list={PhonesName} setList={setPhonesName} animation={150} className="ResponsesSettings">
 				{PhonesName.map(({ id, phone, name }) => (
 					<Response
@@ -118,12 +128,14 @@ function ChangePhone({
 					/>
 				))}
 			</ReactSortable>
-			<Button type={ButtonDisabled ? 'ButtonDisabled' : undefined} value="Ajouter" onclick={addResponse} />
-			<Button
-				type={ButtonDisabled ? 'ButtonDisabled' : undefined}
-				value={ButtonValue}
-				onclick={updateResponses}
-			/>
+			<div>
+				<Button type={ButtonDisabled ? 'ButtonDisabled' : undefined} value="Ajouter" onclick={addResponse} />
+				<Button
+					type={ButtonDisabled ? 'ButtonDisabled' : undefined}
+					value={ButtonValue}
+					onclick={updateResponses}
+				/>
+			</div>
 		</div>
 	);
 }

--- a/src/Pages/Settings/Area/ChangePhone.tsx
+++ b/src/Pages/Settings/Area/ChangePhone.tsx
@@ -1,14 +1,128 @@
-function ChangePhone({ PhonesCombo }: { PhonesCombo: Array<[string /* phone */, string /* name */]> }) {
+import { createRef, useState } from 'react';
+import { ReactSortable } from 'react-sortablejs';
+
+import Delete from '../../../Assets/Images/Delete.svg';
+import Button from '../../../Components/Button';
+import { cleanNumber } from '../../../Utils/Cleaners';
+import axios from 'axios';
+
+function Response({
+	el,
+	remove,
+	update
+}: {
+	el: { id: number; phone: string; name: string };
+	update: (name: string, phone: string) => void;
+	remove: () => void;
+}) {
+	const refname = createRef<HTMLInputElement>();
+	const refPhone = createRef<HTMLInputElement>();
+
 	return (
-		<div>
-			<h2>Change Phone</h2>
-			<select>
-				{PhonesCombo.map(([phone, name]) => (
-					<option key={phone} value={phone}>
-						{name}
-					</option>
+		<div className="Response">
+			<input
+				className="inputField"
+				ref={refname}
+				defaultValue={el.name}
+				onKeyUp={() => update(refname.current!.value, el.phone)}
+			/>
+			<input
+				className="inputField"
+				ref={refPhone}
+				defaultValue={cleanNumber(el.phone)}
+				onKeyUp={() => update(el.name, refPhone.current!.value)}
+			/>
+			<img src={Delete} alt="Delete" onClick={remove} />
+		</div>
+	);
+}
+function ChangePhone({
+	PhonesCombo,
+	credentials
+}: {
+	PhonesCombo: Array<[string /* phone */, string /* name */]>;
+	credentials: Credentials;
+}) {
+	//remove admin phone from PhonesCombo
+	const admin = PhonesCombo.pop();
+
+	const [ButtonDisabled, setButtonDisabled] = useState(false);
+	const [ButtonValue, setButtonValue] = useState('Valider');
+	const [PhonesName, setPhonesName] = useState(
+		PhonesCombo.map(([phone, name], index) => ({ id: index, phone, name }))
+	);
+
+	const addResponse = () => {
+		let id = 0;
+		while (PhonesName.findIndex(val => val.id == id) != -1) id++;
+		setPhonesName(PhonesName.concat({ name: 'Nouveau', phone: '+33000000000', id: id }));
+	};
+
+	function modify(status: Array<{ id: number; phone: string; name: string }>) {
+		console.log(status);
+		return new Promise<boolean>(resolve => {
+			axios
+				.post(credentials.URL + '/admin/area/setPhone', {
+					adminCode: credentials.content.password,
+					area: credentials.content.areaId,
+					phone: status.map((el: { id: number; phone: string; name: string }) => {
+						return [el.phone, el.name];
+					})
+				})
+				.then(() => {
+					resolve(true);
+				})
+				.catch(err => {
+					console.error(err);
+					resolve(false);
+				});
+		});
+	}
+
+	function updateResponses() {
+		if (ButtonDisabled) return;
+		setButtonDisabled(true);
+		setButtonValue('Vérification...');
+
+		modify(PhonesName).then(result => {
+			if (result) {
+				setButtonDisabled(false);
+				setButtonValue('Valider');
+				return;
+			} else {
+				setButtonDisabled(false);
+				setButtonValue('Une erreur est survenue');
+			}
+		});
+	}
+
+	return (
+		<div className="GenericPage">
+			<h2>Changer le numéros des administrateurs</h2>
+			<ReactSortable list={PhonesName} setList={setPhonesName} animation={150} className="ResponsesSettings">
+				{PhonesName.map(({ id, phone, name }) => (
+					<Response
+						update={(updatedName: string, updatedPhone: string) => {
+							const newPhones = PhonesName.map(el =>
+								el.id === id ? { ...el, name: updatedName, phone: updatedPhone } : el
+							);
+							setPhonesName(newPhones);
+						}}
+						key={id}
+						el={{ id, phone, name }}
+						remove={() => {
+							const newPhones = PhonesName.filter(el => el.id !== id);
+							setPhonesName(newPhones);
+						}}
+					/>
 				))}
-			</select>
+			</ReactSortable>
+			<Button type={ButtonDisabled ? 'ButtonDisabled' : undefined} value="Ajouter" onclick={addResponse} />
+			<Button
+				type={ButtonDisabled ? 'ButtonDisabled' : undefined}
+				value={ButtonValue}
+				onclick={updateResponses}
+			/>
 		</div>
 	);
 }

--- a/src/Pages/Settings/Area/ChangePhone.tsx
+++ b/src/Pages/Settings/Area/ChangePhone.tsx
@@ -113,6 +113,7 @@ function ChangePhone({
 						remove={() => {
 							const newPhones = PhonesName.filter(el => el.id !== id);
 							setPhonesName(newPhones);
+							modify(newPhones);
 						}}
 					/>
 				))}

--- a/src/Pages/Settings/Area/ChangePhone.tsx
+++ b/src/Pages/Settings/Area/ChangePhone.tsx
@@ -1,0 +1,15 @@
+function ChangePhone({ PhonesCombo }: { PhonesCombo: Array<[string /* phone */, string /* name */]> }) {
+	return (
+		<div>
+			<h2>Change Phone</h2>
+			<select>
+				{PhonesCombo.map(([phone, name]) => (
+					<option key={phone} value={phone}>
+						{name}
+					</option>
+				))}
+			</select>
+		</div>
+	);
+}
+export default ChangePhone;

--- a/src/Pages/Settings/AreaSettings.tsx
+++ b/src/Pages/Settings/AreaSettings.tsx
@@ -1,13 +1,19 @@
 import axios from 'axios';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { Route, Routes } from 'react-router-dom';
 import Button from '../../Components/Button';
 import Status from '../../Components/Status';
-import React, { useEffect, useState } from 'react';
 import { cleanNumber } from '../../Utils/Cleaners';
-import { Route, Routes } from 'react-router-dom';
 import E404 from '../E404';
-import ChangePhone from './Area/ChangePhone';
-import ChangeAreaPassword from './Area/ChangePassword';
 import ChangeAreaName from './Area/ChangeName';
+import ChangeAreaPassword from './Area/ChangePassword';
+import ChangePhone from './Area/ChangePhone';
+
+const AdminPhoneContext = createContext<{
+	adminPhone: Array<[string, string]>;
+	service: string;
+	enabled: boolean;
+} | null>(null);
 
 function AreaSettings({
 	credentials,
@@ -21,142 +27,135 @@ function AreaSettings({
 		service: string;
 		enabled: boolean;
 	} | null>(null);
-	function AreaSettingsHome({ credentials }: { credentials: Credentials }) {
-		function checkSmsStatus() {
-			return new Promise<{
-				adminPhone: Array<[string, string] /* phone, name */>;
-				service: string;
-				enabled: boolean;
-			}>(resolve => {
-				axios
-					.post(credentials.URL + '/admin/area/smsStatus', {
-						adminCode: credentials.content.password,
-						area: credentials.content.areaId
-					})
-					.then(result => {
-						const data = result.data.data;
-						resolve({
-							adminPhone: data.adminPhone,
-							service: data.service,
-							enabled: data.enabled
-						});
-					})
-					.catch(err => {
-						console.error(err);
-					});
-			});
-		}
 
-		function SendSms() {
-			return new Promise<void>(resolve => {
-				axios
-					.post(credentials.URL + '/admin/area/sendSms', {
-						adminCode: credentials.content.password,
-						area: credentials.content.areaId,
-						phone: smsStatus?.adminPhone || [],
-						message: 'Ceci est un test de sms de tpp. si vous ne reconnaissez pas ce message repondez STOP'
-					})
-					.then(() => {
-						resolve();
-					})
-					.catch(err => {
-						console.error(err);
-					});
-			});
-		}
+	useEffect(() => {
+		checkSmsStatus().then(status => {
+			setSmsStatus(status);
+		});
+	}, []);
 
-		useEffect(() => {
-			if (!smsStatus) {
-				checkSmsStatus().then(status => {
-					setSmsStatus(status);
+	function checkSmsStatus() {
+		return new Promise<{
+			adminPhone: Array<[string /* phone */, string /* name */]>;
+			service: string;
+			enabled: boolean;
+		}>(resolve => {
+			axios
+				.post(credentials.URL + '/admin/area/smsStatus', {
+					adminCode: credentials.content.password,
+					area: credentials.content.areaId
+				})
+				.then(result => {
+					const data = result.data.data;
+					resolve({
+						adminPhone: data.adminPhone,
+						service: data.service,
+						enabled: data.enabled
+					});
+				})
+				.catch(err => {
+					console.error(err);
 				});
-			}
-		}, [smsStatus]);
+		});
+	}
 
-		return (
-			<div className="Settings">
-				<h1>Paramètres de l'organisation</h1>
-				<div>
-					<Button link="ChangeName" value="Changer le nom" />
-					<Button link="ChangePassword" value="Changer le mot de passe d'administration" />
-				</div>
-				<h1>État du service de sms</h1>
-				<div>
-					<div className="smsStatus">
-						<Status
-							status={smsStatus?.enabled ? 'success' : 'muted'}
-							text={smsStatus?.enabled ? 'Actif' : 'Inactif'}
-						/>
-						{smsStatus?.service && (
-							<div>
-								{smsStatus?.service === 'sms-tools' ? (
-									<>
-										sur le service{' '}
-										<a href="https://github.com/sms-tools/sms-tools">
-											<u>sms-tools</u>
-										</a>
-									</>
-								) : smsStatus?.service === 'sms-gateway' ? (
-									<>
-										sur le service{' '}
-										<a href="https://github.com/capcom6/android-sms-gateway">
-											<u>sms-gateway</u>
-										</a>
-									</>
-								) : (
-									<>sur un service inconnu</>
-								)}
-							</div>
-						)}
-					</div>
-					{smsStatus && (
+	return (
+		<AdminPhoneContext.Provider value={smsStatus}>
+			<Routes>
+				<Route path="/" element={<AreaSettingsHome credentials={credentials} />} />
+				<Route
+					path="/ChangePhone"
+					element={
+						smsStatus ? <ChangePhone credentials={credentials} PhonesCombo={smsStatus.adminPhone} /> : <></>
+					}
+				/>
+				<Route
+					path="/ChangePassword"
+					element={<ChangeAreaPassword setCredentials={setCredentials} credentials={credentials} />}
+				/>
+				<Route
+					path="/ChangeName"
+					element={<ChangeAreaName setCredentials={setCredentials} credentials={credentials} />}
+				/>
+				<Route path="/*" element={<E404 />} />
+			</Routes>
+		</AdminPhoneContext.Provider>
+	);
+}
+
+function AreaSettingsHome({ credentials }: { credentials: Credentials }) {
+	const smsStatus = useContext(AdminPhoneContext);
+
+	function SendSms() {
+		return new Promise<void>(resolve => {
+			axios
+				.post(credentials.URL + '/admin/area/sendSms', {
+					adminCode: credentials.content.password,
+					area: credentials.content.areaId,
+					phone: smsStatus?.adminPhone || [],
+					message: 'Ceci est un test de sms de tpp. si vous ne reconnaissez pas ce message repondez STOP'
+				})
+				.then(() => {
+					resolve();
+				})
+				.catch(err => {
+					console.error(err);
+				});
+		});
+	}
+
+	return (
+		<div className="Settings">
+			<h1>Paramètres de l'organisation</h1>
+			<div>
+				<Button link="ChangeName" value="Changer le nom" />
+				<Button link="ChangePassword" value="Changer le mot de passe d'administration" />
+			</div>
+			<h1>État du service de sms</h1>
+			<div>
+				<div className="smsStatus">
+					<Status
+						status={smsStatus?.enabled ? 'success' : 'muted'}
+						text={smsStatus?.enabled ? 'Actif' : 'Inactif'}
+					/>
+					{smsStatus?.service && (
 						<div>
-							<strong>numéros des administrateurs:</strong>
-							<ul>
-								{smsStatus.adminPhone.map(([phone, name], idx) => (
-									<li className="Phone" key={idx}>
-										{cleanNumber(phone)} - {name}
-									</li>
-								))}
-							</ul>
-							<Button value="tester ces numeros" onclick={SendSms} />
-							<Button value="mettre a jour les numeros" link="ChangePhone" />
+							{smsStatus?.service === 'sms-tools' ? (
+								<>
+									sur le service{' '}
+									<a href="https://github.com/sms-tools/sms-tools">
+										<u>sms-tools</u>
+									</a>
+								</>
+							) : smsStatus?.service === 'sms-gateway' ? (
+								<>
+									sur le service{' '}
+									<a href="https://github.com/capcom6/android-sms-gateway">
+										<u>sms-gateway</u>
+									</a>
+								</>
+							) : (
+								<>sur un service inconnu</>
+							)}
 						</div>
 					)}
 				</div>
+				{smsStatus?.adminPhone && (
+					<div>
+						<strong>numéros des administrateurs:</strong>
+						<ul>
+							{smsStatus.adminPhone.map(([phone, name], idx) => (
+								<li className="Phone" key={idx}>
+									{cleanNumber(phone)} - {name}
+								</li>
+							))}
+						</ul>
+						<Button value="tester ces numeros" onclick={SendSms} />
+						<Button value="mettre a jour les numeros" link="ChangePhone" />
+					</div>
+				)}
 			</div>
-		);
-	}
-	const routes = [
-		{
-			path: '/',
-			element: <AreaSettingsHome credentials={credentials} />
-		},
-		{
-			path: '/ChangePhone',
-			element: smsStatus ? <ChangePhone PhonesCombo={smsStatus.adminPhone} /> : <></>
-		},
-
-		{
-			path: '/ChangePassword',
-			element: <ChangeAreaPassword setCredentials={setCredentials} credentials={credentials} />
-		},
-		{
-			path: '/ChangeName',
-			element: <ChangeAreaName setCredentials={setCredentials} credentials={credentials} />
-		},
-		{
-			path: '/*',
-			element: <E404 />
-		}
-	];
-
-	return (
-		<Routes>
-			{routes.map((element, i) => {
-				return <Route path={element.path} element={element.element} key={i} />;
-			})}
-		</Routes>
+		</div>
 	);
 }
 

--- a/src/Pages/Settings/AreaSettings.tsx
+++ b/src/Pages/Settings/AreaSettings.tsx
@@ -1,12 +1,114 @@
+import axios from 'axios';
 import Button from '../../Components/Button';
+import Status from '../../Components/Status';
+import { useEffect, useState } from 'react';
+import { cleanNumber } from '../../Utils/Cleaners';
 
-function AreaSettings() {
+function AreaSettings({ credentials }: { credentials: Credentials }) {
+	function checkSmsStatus() {
+		return new Promise<{
+			adminPhone: Array<string>;
+			service: string;
+			enabled: boolean;
+		}>(resolve => {
+			axios
+				.post(credentials.URL + '/admin/area/smsStatus', {
+					adminCode: credentials.content.password,
+					area: credentials.content.areaId
+				})
+				.then(result => {
+					const data = result.data.data;
+					resolve({
+						adminPhone: data.adminPhone,
+						service: data.service,
+						enabled: data.enabled
+					});
+				})
+				.catch(err => {
+					console.error(err);
+				});
+		});
+	}
+
+	function SendSms() {
+		return new Promise<void>(resolve => {
+			axios
+				.post(credentials.URL + '/admin/area/sendSms', {
+					adminCode: credentials.content.password,
+					area: credentials.content.areaId,
+					phone: smsStatus?.adminPhone || [],
+					message: 'Ceci est un test de sms de tpp. si vous ne reconnaissez pas ce message repondez STOP'
+				})
+				.then(() => {
+					resolve();
+				})
+				.catch(err => {
+					console.error(err);
+				});
+		});
+	}
+
+	const [smsStatus, setSmsStatus] = useState<{
+		adminPhone: Array<string>;
+		service: string;
+		enabled: boolean;
+	} | null>(null);
+
+	useEffect(() => {
+		checkSmsStatus().then(status => {
+			setSmsStatus(status);
+		});
+	}, []);
+
 	return (
 		<div className="Settings">
 			<h1>Paramètres de l'organisation</h1>
 			<div>
 				<Button link="ChangeName" value="Changer le nom" />
 				<Button link="ChangePassword" value="Changer le mot de passe d'administration" />
+			</div>
+			<h1>État du service de sms</h1>
+			<div>
+				<div className="smsStatus">
+					<Status
+						status={smsStatus?.enabled ? 'success' : 'muted'}
+						text={smsStatus?.enabled ? 'Actif' : 'Inactif'}
+					/>
+					{smsStatus?.service && (
+						<div>
+							{smsStatus?.service === 'sms-tools' ? (
+								<>
+									sur le service{' '}
+									<a href="https://github.com/sms-tools/sms-tools">
+										<u>sms-tools</u>
+									</a>
+								</>
+							) : smsStatus?.service === 'sms-gateway' ? (
+								<>
+									sur le service{' '}
+									<a href="https://github.com/capcom6/android-sms-gateway">
+										<u>sms-gateway</u>
+									</a>
+								</>
+							) : (
+								<>sur un service inconnu</>
+							)}
+						</div>
+					)}
+				</div>
+				{smsStatus && (
+					<div>
+						<strong>numéros des administrateurs:</strong>
+						<ul>
+							{smsStatus.adminPhone.map(([phone, name], idx) => (
+								<li className="Phone" key={idx}>
+									{cleanNumber(phone)} - {name}
+								</li>
+							))}
+						</ul>
+						<Button value="tester ces numeros" onclick={SendSms} />
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/src/Pages/Settings/AreaSettings.tsx
+++ b/src/Pages/Settings/AreaSettings.tsx
@@ -150,10 +150,10 @@ function AreaSettingsHome({ credentials }: { credentials: Credentials }) {
 								</li>
 							))}
 						</ul>
-						<Button value="tester ces numeros" onclick={SendSms} />
-						<Button value="mettre a jour les numeros" link="ChangePhone" />
 					</div>
 				)}
+				<Button value="mettre a jour les numeros" link="ChangePhone" />
+				<Button value="tester ces numeros" onclick={SendSms} />
 			</div>
 		</div>
 	);

--- a/src/Pages/Settings/AreaSettings.tsx
+++ b/src/Pages/Settings/AreaSettings.tsx
@@ -1,116 +1,162 @@
 import axios from 'axios';
 import Button from '../../Components/Button';
 import Status from '../../Components/Status';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { cleanNumber } from '../../Utils/Cleaners';
+import { Route, Routes } from 'react-router-dom';
+import E404 from '../E404';
+import ChangePhone from './Area/ChangePhone';
+import ChangeAreaPassword from './Area/ChangePassword';
+import ChangeAreaName from './Area/ChangeName';
 
-function AreaSettings({ credentials }: { credentials: Credentials }) {
-	function checkSmsStatus() {
-		return new Promise<{
-			adminPhone: Array<string>;
-			service: string;
-			enabled: boolean;
-		}>(resolve => {
-			axios
-				.post(credentials.URL + '/admin/area/smsStatus', {
-					adminCode: credentials.content.password,
-					area: credentials.content.areaId
-				})
-				.then(result => {
-					const data = result.data.data;
-					resolve({
-						adminPhone: data.adminPhone,
-						service: data.service,
-						enabled: data.enabled
-					});
-				})
-				.catch(err => {
-					console.error(err);
-				});
-		});
-	}
-
-	function SendSms() {
-		return new Promise<void>(resolve => {
-			axios
-				.post(credentials.URL + '/admin/area/sendSms', {
-					adminCode: credentials.content.password,
-					area: credentials.content.areaId,
-					phone: smsStatus?.adminPhone || [],
-					message: 'Ceci est un test de sms de tpp. si vous ne reconnaissez pas ce message repondez STOP'
-				})
-				.then(() => {
-					resolve();
-				})
-				.catch(err => {
-					console.error(err);
-				});
-		});
-	}
-
+function AreaSettings({
+	credentials,
+	setCredentials
+}: {
+	credentials: Credentials;
+	setCredentials: (credentials: Credentials) => void;
+}) {
 	const [smsStatus, setSmsStatus] = useState<{
-		adminPhone: Array<string>;
+		adminPhone: Array<[string /* phone */, string /* name */]>;
 		service: string;
 		enabled: boolean;
 	} | null>(null);
+	function AreaSettingsHome({ credentials }: { credentials: Credentials }) {
+		function checkSmsStatus() {
+			return new Promise<{
+				adminPhone: Array<[string, string] /* phone, name */>;
+				service: string;
+				enabled: boolean;
+			}>(resolve => {
+				axios
+					.post(credentials.URL + '/admin/area/smsStatus', {
+						adminCode: credentials.content.password,
+						area: credentials.content.areaId
+					})
+					.then(result => {
+						const data = result.data.data;
+						resolve({
+							adminPhone: data.adminPhone,
+							service: data.service,
+							enabled: data.enabled
+						});
+					})
+					.catch(err => {
+						console.error(err);
+					});
+			});
+		}
 
-	useEffect(() => {
-		checkSmsStatus().then(status => {
-			setSmsStatus(status);
-		});
-	}, []);
+		function SendSms() {
+			return new Promise<void>(resolve => {
+				axios
+					.post(credentials.URL + '/admin/area/sendSms', {
+						adminCode: credentials.content.password,
+						area: credentials.content.areaId,
+						phone: smsStatus?.adminPhone || [],
+						message: 'Ceci est un test de sms de tpp. si vous ne reconnaissez pas ce message repondez STOP'
+					})
+					.then(() => {
+						resolve();
+					})
+					.catch(err => {
+						console.error(err);
+					});
+			});
+		}
 
-	return (
-		<div className="Settings">
-			<h1>Paramètres de l'organisation</h1>
-			<div>
-				<Button link="ChangeName" value="Changer le nom" />
-				<Button link="ChangePassword" value="Changer le mot de passe d'administration" />
-			</div>
-			<h1>État du service de sms</h1>
-			<div>
-				<div className="smsStatus">
-					<Status
-						status={smsStatus?.enabled ? 'success' : 'muted'}
-						text={smsStatus?.enabled ? 'Actif' : 'Inactif'}
-					/>
-					{smsStatus?.service && (
+		useEffect(() => {
+			if (!smsStatus) {
+				checkSmsStatus().then(status => {
+					setSmsStatus(status);
+				});
+			}
+		}, [smsStatus]);
+
+		return (
+			<div className="Settings">
+				<h1>Paramètres de l'organisation</h1>
+				<div>
+					<Button link="ChangeName" value="Changer le nom" />
+					<Button link="ChangePassword" value="Changer le mot de passe d'administration" />
+				</div>
+				<h1>État du service de sms</h1>
+				<div>
+					<div className="smsStatus">
+						<Status
+							status={smsStatus?.enabled ? 'success' : 'muted'}
+							text={smsStatus?.enabled ? 'Actif' : 'Inactif'}
+						/>
+						{smsStatus?.service && (
+							<div>
+								{smsStatus?.service === 'sms-tools' ? (
+									<>
+										sur le service{' '}
+										<a href="https://github.com/sms-tools/sms-tools">
+											<u>sms-tools</u>
+										</a>
+									</>
+								) : smsStatus?.service === 'sms-gateway' ? (
+									<>
+										sur le service{' '}
+										<a href="https://github.com/capcom6/android-sms-gateway">
+											<u>sms-gateway</u>
+										</a>
+									</>
+								) : (
+									<>sur un service inconnu</>
+								)}
+							</div>
+						)}
+					</div>
+					{smsStatus && (
 						<div>
-							{smsStatus?.service === 'sms-tools' ? (
-								<>
-									sur le service{' '}
-									<a href="https://github.com/sms-tools/sms-tools">
-										<u>sms-tools</u>
-									</a>
-								</>
-							) : smsStatus?.service === 'sms-gateway' ? (
-								<>
-									sur le service{' '}
-									<a href="https://github.com/capcom6/android-sms-gateway">
-										<u>sms-gateway</u>
-									</a>
-								</>
-							) : (
-								<>sur un service inconnu</>
-							)}
+							<strong>numéros des administrateurs:</strong>
+							<ul>
+								{smsStatus.adminPhone.map(([phone, name], idx) => (
+									<li className="Phone" key={idx}>
+										{cleanNumber(phone)} - {name}
+									</li>
+								))}
+							</ul>
+							<Button value="tester ces numeros" onclick={SendSms} />
+							<Button value="mettre a jour les numeros" link="ChangePhone" />
 						</div>
 					)}
 				</div>
-				{smsStatus && (
-					<div>
-						<strong>numéros des administrateurs:</strong>
-						<ul>
-							{smsStatus.adminPhone.map(([phone, name], idx) => (
-								<li className="Phone" key={idx}>
-									{cleanNumber(phone)} - {name}
-								</li>
-							))}
-						</ul>
-						<Button value="tester ces numeros" onclick={SendSms} />
-					</div>
-				)}
 			</div>
-		</div>
+		);
+	}
+	const routes = [
+		{
+			path: '/',
+			element: <AreaSettingsHome credentials={credentials} />
+		},
+		{
+			path: '/ChangePhone',
+			element: smsStatus ? <ChangePhone PhonesCombo={smsStatus.adminPhone} /> : <></>
+		},
+
+		{
+			path: '/ChangePassword',
+			element: <ChangeAreaPassword setCredentials={setCredentials} credentials={credentials} />
+		},
+		{
+			path: '/ChangeName',
+			element: <ChangeAreaName setCredentials={setCredentials} credentials={credentials} />
+		},
+		{
+			path: '/*',
+			element: <E404 />
+		}
+	];
+
+	return (
+		<Routes>
+			{routes.map((element, i) => {
+				return <Route path={element.path} element={element.element} key={i} />;
+			})}
+		</Routes>
 	);
 }
 

--- a/src/Pages/Settings/Settings.tsx
+++ b/src/Pages/Settings/Settings.tsx
@@ -3,8 +3,6 @@ import { Route, Routes } from 'react-router-dom';
 import Button from '../../Components/Button';
 import { clearCredentials } from '../../Utils/Storage';
 import E404 from '../E404';
-import ChangeAreaName from './Area/ChangeName';
-import ChangeAreaPassword from './Area/ChangePassword';
 import AreaSettings from './AreaSettings';
 import Campaign from './Campaign/Campaign';
 import CampaignsSettings from './Campaigns';

--- a/src/Pages/Settings/Settings.tsx
+++ b/src/Pages/Settings/Settings.tsx
@@ -45,7 +45,7 @@ function Settings({
 		},
 		{
 			path: '/Area',
-			element: <AreaSettings />
+			element: <AreaSettings credentials={credentials} />
 		},
 		{
 			path: '/Area/ChangePassword',

--- a/src/Pages/Settings/Settings.tsx
+++ b/src/Pages/Settings/Settings.tsx
@@ -3,6 +3,8 @@ import { Route, Routes } from 'react-router-dom';
 import Button from '../../Components/Button';
 import { clearCredentials } from '../../Utils/Storage';
 import E404 from '../E404';
+import ChangeAreaName from './Area/ChangeName';
+import ChangeAreaPassword from './Area/ChangePassword';
 import AreaSettings from './AreaSettings';
 import Campaign from './Campaign/Campaign';
 import CampaignsSettings from './Campaigns';

--- a/src/Pages/Settings/Settings.tsx
+++ b/src/Pages/Settings/Settings.tsx
@@ -3,8 +3,6 @@ import { Route, Routes } from 'react-router-dom';
 import Button from '../../Components/Button';
 import { clearCredentials } from '../../Utils/Storage';
 import E404 from '../E404';
-import ChangeAreaName from './Area/ChangeName';
-import ChangeAreaPassword from './Area/ChangePassword';
 import AreaSettings from './AreaSettings';
 import Campaign from './Campaign/Campaign';
 import CampaignsSettings from './Campaigns';
@@ -44,16 +42,8 @@ function Settings({
 			element: <SettingsHome renderLogin={renderLogin} />
 		},
 		{
-			path: '/Area',
-			element: <AreaSettings credentials={credentials} />
-		},
-		{
-			path: '/Area/ChangePassword',
-			element: <ChangeAreaPassword setCredentials={setCredentials} credentials={credentials} />
-		},
-		{
-			path: '/Area/ChangeName',
-			element: <ChangeAreaName setCredentials={setCredentials} credentials={credentials} />
+			path: '/Area/*',
+			element: <AreaSettings credentials={credentials} setCredentials={setCredentials} />
 		},
 		{
 			path: '/Campaigns',

--- a/src/Stylesheets/index.scss
+++ b/src/Stylesheets/index.scss
@@ -343,6 +343,13 @@ h4 {
 	gap: 2vh;
 }
 
+.Settings .smsStatus {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 0.3em;
+}
+
 .HoursChange {
 	display: flex;
 	align-items: center;
@@ -440,5 +447,31 @@ a.Active {
 	}
 	& > span {
 		font-weight: bold;
+	}
+}
+
+.circle {
+	border-radius: 50%;
+	height: 1.2em;
+	width: 1.2em;
+}
+.status {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5em;
+
+	.circle.success {
+		background-color: var(--color1v1);
+		border: 2px solid var(--color1v1Border);
+	}
+
+	.circle.danger {
+		background-color: var(--color2v1);
+		border: 2px solid var(--color2v1Border);
+	}
+
+	.circle.muted {
+		background-color: var(--disabledButton);
+		border: 2px solid var(--disabledButtonBorder);
 	}
 }

--- a/src/Stylesheets/index.scss
+++ b/src/Stylesheets/index.scss
@@ -274,6 +274,13 @@ h4 {
 	max-width: max-content;
 }
 
+.GenericPage > p {
+	margin: auto;
+	width: 50vw;
+	font-size: 1.2em;
+	text-align: justify;
+}
+
 .RemovePage > div > span {
 	font-size: 1.3em;
 	font-weight: bold;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { mobileCheck } from './Utils/Utils';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
-const URL = 'https://pp.mpqa.fr/api';
+const URL = 'http://localhost:8081';
 
 function renderApp(credentials: Credentials, campaign: Campaign) {
 	credentials.URL = URL;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { mobileCheck } from './Utils/Utils';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
-const URL = 'http://localhost:8081';
+const URL = 'https://pp.mpqa.fr/api';
 
 function renderApp(credentials: Credentials, campaign: Campaign) {
 	credentials.URL = URL;


### PR DESCRIPTION
## Pull Request Overview

Adds SMS support to the area settings, including status display and phone management.

- Introduces SMS status retrieval and display in the AreaSettings component  
- Provides a ChangePhone page for editing, adding, and testing admin phone numbers  
- Adds new styles for generic pages, SMS status layout, and status indicator circles

### Screenshot
<img width="649" height="676" alt="Capture d’écran 2025-07-11 à 00 39 09" src="https://github.com/user-attachments/assets/9247decd-f84a-4a46-b763-3cf9ff08c22b" />
<img width="1919" height="674" alt="Capture d’écran 2025-07-11 à 00 32 49" src="https://github.com/user-attachments/assets/36a2fd0a-967a-42f4-8148-57106c02a2cb" />



### Reviewed Changes

Copilot reviewed 5 out of 5 changed files in this pull request and generated 3 comments.

<details>
<summary>Show a summary per file</summary>

| File                                       | Description                                                                                  |
|--------------------------------------------|----------------------------------------------------------------------------------------------|
| src/Stylesheets/index.scss                 | Added `.GenericPage` text styles, `.smsStatus` layout, and `.circle`/`.status` indicator CSS |
| src/Pages/Settings/Settings.tsx            | Merged individual Area routes into `'/Area/*'` and passed credentials to `AreaSettings`      |
| src/Pages/Settings/AreaSettings.tsx        | New component to fetch and display SMS service status and admin phone list                   |
| src/Pages/Settings/Area/ChangePhone.tsx    | New UI for modifying, adding, removing, and testing administrator phone numbers              |
| src/Components/Status.tsx                  | New reusable `Status` component rendering a colored circle and label                         |
</details>



<details>
<summary>Comments suppressed due to low confidence (3)</summary>

**src/Pages/Settings/Area/ChangePhone.tsx:47**
* [nitpick] The setter `setadmin` should follow camelCase conventions (e.g., `setAdmin`) to match React state naming best practices.
```
	const [admin, setadmin] = useState(adminPhone);
```
**src/Pages/Settings/Area/ChangePhone.tsx:52**
* [nitpick] State variables should be camelCase. Rename `ButtonDisabled` and `ButtonValue` to `buttonDisabled` and `buttonValue` for consistency.
```
	const [ButtonDisabled, setButtonDisabled] = useState(false);
```
**src/Pages/Settings/AreaSettings.tsx:31**
* The new SMS status fetch logic isn’t covered by existing tests. Consider adding unit or integration tests for `checkSmsStatus` and the associated UI rendering.
```
	useEffect(() => {
```
</details>

